### PR TITLE
Add PostgreSQL initialization and wire task model to database

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,15 @@
+# Copy this file to .env and adjust values as needed for local development
+
+# Database
+DB_NAME=tasksdb
+DB_USER=postgres
+DB_PASSWORD=postgres123
+DB_HOST=db
+DB_PORT=5432
+
+# API
+API_PORT=5000
+NODE_ENV=development
+
+# Frontend
+REACT_APP_API_URL=http://localhost:5000

--- a/api/config/database.js
+++ b/api/config/database.js
@@ -10,7 +10,7 @@ const pool = new Pool({
   port: Number(process.env.DB_PORT) || 5432,
   user: process.env.DB_USER || "postgres",
   password: process.env.DB_PASSWORD || "postgres",
-  database: process.env.DB_NAME || "tasks_db",
+  database: process.env.DB_NAME || "tasksdb",
   max: Number(process.env.DB_POOL_MAX) || 10,
   idleTimeoutMillis: Number(process.env.DB_IDLE_TIMEOUT) || 30000,
 });

--- a/api/models/Task.js
+++ b/api/models/Task.js
@@ -2,14 +2,11 @@ import pool from "../config/database.js";
 
 const Task = {
   async getAll() {
-    // mock data
-    return [
-      { id: 1, title: "First task" },
-      { id: 2, title: "Second task" },
-    ]; // Повертаємо MOCK дані
-    // const result = await pool.query("SELECT * FROM tasks ORDER BY id ASC");
-    // return [];
-    // return result.rows;
+    const result = await pool.query(
+      "SELECT id, title, created_at FROM tasks ORDER BY created_at DESC",
+    );
+
+    return result.rows;
   },
 
   async create({ title }) {
@@ -21,10 +18,12 @@ const Task = {
       throw error;
     }
 
-    console.log('*** RESULT ***: ', trimmedTitle);
-    
+    const result = await pool.query(
+      "INSERT INTO tasks (title) VALUES ($1) RETURNING id, title, created_at",
+      [trimmedTitle],
+    );
 
-    return trimmedTitle;
+    return result.rows[0];
   },
 };
 

--- a/api/routes/tasks.js
+++ b/api/routes/tasks.js
@@ -14,9 +14,6 @@ router.get("/", async (req, res, next) => {
 
 router.post("/", async (req, res, next) => {
   try {
-    
-    console.log('req.body: ', req.body);
-    
     const task = await Task.create(req.body || {});
     res.status(201).json(task);
   } catch (error) {

--- a/db/init.sql
+++ b/db/init.sql
@@ -1,0 +1,14 @@
+-- Initialize tasks database schema
+CREATE TABLE IF NOT EXISTS tasks (
+    id SERIAL PRIMARY KEY,
+    title VARCHAR(255) NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+INSERT INTO tasks (title) VALUES
+    ('Sample task 1'),
+    ('Sample task 2'),
+    ('Sample task 3')
+ON CONFLICT DO NOTHING;
+
+CREATE INDEX IF NOT EXISTS idx_tasks_created_at ON tasks (created_at);


### PR DESCRIPTION
## Summary
- add project-level environment configuration template (.env.example) with API, frontend, and database settings
- create PostgreSQL initialization script for tasks table, seed data, and index
- connect task model and routes to PostgreSQL queries using the shared pool configuration

## Testing
- npm run format

------
https://chatgpt.com/codex/tasks/task_e_68e24997dec8832d842c55e68f0735b4